### PR TITLE
fix: deprecated `set-output` command

### DIFF
--- a/.github/workflows/ruby-release-reusable.yml
+++ b/.github/workflows/ruby-release-reusable.yml
@@ -43,10 +43,8 @@ jobs:
       - name: Push tag
         run: git push --follow-tags
       - name: Get tag
-        run: echo "::set-output name=name::$(git describe --abbrev=0)"
-        id: tag
+        run: echo "TAG_NAME=$(git describe --abbrev=0)" >> "${GITHUB_ENV}"
       - name: Create GitHub release
         run: gh release create "${TAG_NAME}" --draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ steps.tag.outputs.name }}


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
