### PR TITLE
feat: set `permissions.id-token: write` for Node.js Release workflow

### DIFF
--- a/.github/workflows/nodejs-release-reusable.yml
+++ b/.github/workflows/nodejs-release-reusable.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     timeout-minutes: 10
     steps:
       - name: Checkout


### PR DESCRIPTION
To support provenance publishing on npm.
See https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
