### PR TITLE
feat: add `minimum-ruby-version` to `ruby-test-reusable.yml` workflow

### DIFF
--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -11,3 +11,8 @@ jobs:
     uses: ./.github/workflows/ruby-test-reusable.yml
     with:
       os: '["ubuntu-latest"]'
+
+  test-minimum:
+    uses: ./.github/workflows/ruby-test-reusable.yml
+    with:
+      minimum-ruby-version: 3.2

--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -15,4 +15,5 @@ jobs:
   test-minimum:
     uses: ./.github/workflows/ruby-test-reusable.yml
     with:
-      minimum-ruby-version: 3.2
+      os: '["ubuntu-latest"]'
+      minimum-ruby-version: 2.7

--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -11,9 +11,3 @@ jobs:
     uses: ./.github/workflows/ruby-test-reusable.yml
     with:
       os: '["ubuntu-latest"]'
-
-  test-minimum:
-    uses: ./.github/workflows/ruby-test-reusable.yml
-    with:
-      os: '["ubuntu-latest"]'
-      minimum-ruby-version: 2.7

--- a/.github/workflows/ruby-test-reusable.yml
+++ b/.github/workflows/ruby-test-reusable.yml
@@ -32,7 +32,7 @@ jobs:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
       engine: cruby
-      min_version: ${{ inputs.minimum-ruby-version }}
+      min_version: ${{ inputs.minimum-ruby-version || 0 }}
 
   test:
     needs: ruby-versions

--- a/.github/workflows/ruby-test-reusable.yml
+++ b/.github/workflows/ruby-test-reusable.yml
@@ -13,6 +13,11 @@ on:
         required: false
         default: "ruby" # latest
         type: string
+      minimum-ruby-version:
+        description: Default Ruby version
+        required: false
+        default: ""
+        type: string
       os:
         description: OS name
         required: false
@@ -27,6 +32,7 @@ jobs:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
       engine: cruby
+      min_version: ${{ inputs.minimum-ruby-version }}
 
   test:
     needs: ruby-versions

--- a/.github/workflows/ruby-test-reusable.yml
+++ b/.github/workflows/ruby-test-reusable.yml
@@ -14,7 +14,7 @@ on:
         default: "ruby" # latest
         type: string
       minimum-ruby-version:
-        description: Default Ruby version
+        description: Minimum Ruby version
         required: false
         type: number
       os:

--- a/.github/workflows/ruby-test-reusable.yml
+++ b/.github/workflows/ruby-test-reusable.yml
@@ -16,8 +16,7 @@ on:
       minimum-ruby-version:
         description: Default Ruby version
         required: false
-        default: ""
-        type: string
+        type: number
       os:
         description: OS name
         required: false
@@ -32,7 +31,7 @@ jobs:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
       engine: cruby
-      min_version: ${{ inputs.minimum-ruby-version || 0 }}
+      min_version: ${{ inputs.minimum-ruby-version }}
 
   test:
     needs: ruby-versions


### PR DESCRIPTION
See https://github.com/ruby/actions/blob/cf3a31799796546281e6fe21ab4d2bd8e965caed/.github/workflows/ruby_versions.yml#L14-L16

Usage:

```yaml
test:
  uses: ./.github/workflows/ruby-test-reusable.yml
  with:
    minimum-ruby-version: 2.7
```