### PR TITLE
fix: test error on Node.js v18 and npm v11

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["lts/*", "20", "16"]
+        node-version: ["lts/*", "20", "18", "16"]
         os: ["ubuntu-latest"]
     uses: ./.github/workflows/nodejs-test-reusable.yml
     with:

--- a/.github/workflows/nodejs-test-reusable.yml
+++ b/.github/workflows/nodejs-test-reusable.yml
@@ -46,13 +46,18 @@ jobs:
 
       - name: Update npm to latest
         shell: bash
-        # NOTE: npm v10 has dropped support for Node.js v16.
         run: |
-          if [[ $(node -v) =~ ^v(16|14|12|10)\. ]]; then
-            npm install --global npm@9
-          else
-            npm install --global npm@latest
-          fi
+          case $(node -v) in
+            v16.*|v14.*|v12.*|v10.*)
+              npm install --global npm@9
+              ;;
+            v18.*)
+              npm install --global npm@10
+              ;;
+            *)
+              npm install --global npm@latest
+              ;;
+          esac
           echo "Successfully updated npm to $(npm -v)"
 
       - name: Install dependencies


### PR DESCRIPTION
npm v11 has dropped the support for Node.js v18:
https://github.com/npm/cli/releases/tag/v11.0.0

So this change installs npm v10 instead on Nodde.js v18.

```sh-session
$ npm v npm@11.0.0 engines
{ node: '^20.17.0 || >=22.9.0' }

$ npm v npm@10.9.2 engines
{ node: '^18.17.0 || >=20.5.0' }
```
