### PR TITLE
fix: make updated npm version more accurate in action logs

### DIFF
--- a/.github/workflows/nodejs-test-reusable.yml
+++ b/.github/workflows/nodejs-test-reusable.yml
@@ -44,21 +44,28 @@ jobs:
           node-version: ${{ inputs.node-version }}
           cache: npm
 
-      - name: Update npm to latest
+      - name: Get npm version
+        id: npm-version
         shell: bash
         run: |
           case $(node -v) in
             v16.*|v14.*|v12.*|v10.*)
-              npm install --global npm@9
+              npm_version=9
               ;;
             v18.*)
-              npm install --global npm@10
+              npm_version=10
               ;;
             *)
-              npm install --global npm@latest
+              npm_version=latest
               ;;
           esac
-          echo "Successfully updated npm to $(npm -v)"
+          echo "version=${npm_version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Update npm to ${{ steps.npm-version.outputs.version }}
+        shell: bash
+        env:
+          npm_version: ${{ steps.npm-version.outputs.version }}
+        run: npm install --global "npm@${npm_version}"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/nodejs-test-reusable.yml
+++ b/.github/workflows/nodejs-test-reusable.yml
@@ -57,11 +57,13 @@ jobs:
               ;;
             *)
               npm_version=latest
+              echo "latest=true" >> "${GITHUB_OUTPUT}"
               ;;
           esac
+          npm_version=$(npm view "npm@${npm_version}" version)
           echo "version=${npm_version}" >> "${GITHUB_OUTPUT}"
 
-      - name: Update npm to ${{ steps.npm-version.outputs.version }}
+      - name: Update npm to ${{ steps.npm-version.outputs.version }}${{ steps.npm-version.outputs.latest && ' (latest)' }}
         shell: bash
         env:
           npm_version: ${{ steps.npm-version.outputs.version }}

--- a/.github/workflows/nodejs-test-reusable.yml
+++ b/.github/workflows/nodejs-test-reusable.yml
@@ -50,18 +50,19 @@ jobs:
         run: |
           case $(node -v) in
             v16.*|v14.*|v12.*|v10.*)
-              npm_version=9
+              major_version=9
               ;;
             v18.*)
-              npm_version=10
+              major_version=10
               ;;
             *)
-              npm_version=latest
               echo "latest=true" >> "${GITHUB_OUTPUT}"
+              echo "version=$(npm view npm version)" >> "${GITHUB_OUTPUT}"
+              exit 0
               ;;
           esac
-          npm_version=$(npm view "npm@${npm_version}" version)
-          echo "version=${npm_version}" >> "${GITHUB_OUTPUT}"
+          version=$(npm view "npm@${major_version}" version --json | jq -r '.[-1]')
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
 
       - name: Update npm to ${{ steps.npm-version.outputs.version }}${{ steps.npm-version.outputs.latest && ' (latest)' }}
         shell: bash


### PR DESCRIPTION
The current log message "Update npm to latest" is not accurate because npm can be updated to v9 or v10.

E.g. https://github.com/ybiquitous/.github/actions/runs/12461745399/job/34781727243
<img width="232" alt="image" src="https://github.com/user-attachments/assets/d8a9dd8d-409c-4746-99b2-1202b5906b13" />
