### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -25,6 +25,8 @@ jobs:
   show-coverage:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/ybiquitous/.github/security/code-scanning/3](https://github.com/ybiquitous/.github/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the `show-coverage` job. Since the job only performs read-only operations (downloading an artifact and listing its contents), the minimal required permission is `contents: read`. This change ensures that the job does not inherit unnecessary write permissions from the repository or organization settings.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
