### PR TITLE
fix: pin all outside actions for security

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Run actionlint
         uses: docker://rhysd/actionlint:latest
         with:

--- a/.github/workflows/dependabot-auto-merge-reusable.yml
+++ b/.github/workflows/dependabot-auto-merge-reusable.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0
       - name: Enable auto-merge
         if: ${{ !contains(fromJSON(inputs.excluded-update-types), steps.metadata.outputs.update-type) }}
         run: gh pr merge --auto "--${MERGE_OPTION}" "$PR_URL"

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -28,7 +28,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: coverage
           path: downloaded/

--- a/.github/workflows/nodejs-lint-reusable.yml
+++ b/.github/workflows/nodejs-lint-reusable.yml
@@ -11,11 +11,11 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Set up Node.js LTS
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "lts/*"
           cache: npm

--- a/.github/workflows/nodejs-release-reusable.yml
+++ b/.github/workflows/nodejs-release-reusable.yml
@@ -30,10 +30,10 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Node.js LTS
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "lts/*"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/nodejs-test-reusable.yml
+++ b/.github/workflows/nodejs-test-reusable.yml
@@ -36,10 +36,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Node.js ${{ inputs.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ inputs.node-version }}
           cache: npm
@@ -82,7 +82,7 @@ jobs:
         if: ${{ inputs.node-version == inputs.node-version-coverage }}
 
       - name: Upload test coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ inputs.node-version == inputs.node-version-coverage }}
         with:
           name: ${{ inputs.coverage-name }}

--- a/.github/workflows/ruby-release-reusable.yml
+++ b/.github/workflows/ruby-release-reusable.yml
@@ -25,9 +25,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Ruby ${{ inputs.ruby-version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@c95ae3725f6ebdd095f2bd19caed7ebc14435ba5 # v1.243.0
         with:
           ruby-version: ${{ inputs.ruby-version }}
           bundler-cache: true

--- a/.github/workflows/ruby-test-reusable.yml
+++ b/.github/workflows/ruby-test-reusable.yml
@@ -44,9 +44,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Ruby (${{ matrix.ruby-version }})
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@c95ae3725f6ebdd095f2bd19caed7ebc14435ba5 # v1.243.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
@@ -58,9 +58,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Ruby (${{ inputs.default-ruby-version }})
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@c95ae3725f6ebdd095f2bd19caed7ebc14435ba5 # v1.243.0
         with:
           ruby-version: ${{ inputs.default-ruby-version }}
           bundler-cache: true


### PR DESCRIPTION
Ref https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
