### PR TITLE
fix: missing `id-token` permission in `nodejs-release.yml`

### DIFF
--- a/.github/workflows/nodejs-release.yml
+++ b/.github/workflows/nodejs-release.yml
@@ -15,3 +15,4 @@ jobs:
       publish: false
     permissions:
       contents: write
+      id-token: write


### PR DESCRIPTION
Ref https://github.com/ybiquitous/.github/actions/runs/15131883448/workflow
