### PR TITLE
fix: pin ruby/actions workflow to specific SHA commit

### DIFF
--- a/.github/workflows/ruby-test-reusable.yml
+++ b/.github/workflows/ruby-test-reusable.yml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   ruby-versions:
-    uses: ruby/actions/.github/workflows/ruby_versions.yml@master
+    uses: ruby/actions/.github/workflows/ruby_versions.yml@e6eba27f7a9c48ccccb2eef935b8de5ba3facf8b
     with:
       engine: cruby
       min_version: ${{ inputs.minimum-ruby-version }}


### PR DESCRIPTION
This PR pins the `ruby/actions/.github/workflows/ruby_versions.yml` workflow reference from `@master` to a specific SHA commit `@e6eba27f7a9c48ccccb2eef935b8de5ba3facf8b` for improved security and reproducible builds.

## Changes
- Replace `@master` with `@e6eba27f7a9c48ccccb2eef935b8de5ba3facf8b` in `ruby-test-reusable.yml`

## Benefits
- **Security**: Prevents potential supply chain attacks by pinning to an immutable commit
- **Reproducibility**: Ensures consistent behavior across workflow runs
- **Transparency**: Makes it clear which version of the external workflow is being used

The pinned commit (e6eba27f7a9c48ccccb2eef935b8de5ba3facf8b) is the latest commit that modified the `ruby_versions.yml` workflow file as of August 16, 2025.