### PR TITLE
ci: replace Docker action with `docker run` command in actionlint workflow

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -21,4 +21,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Run actionlint
-        run: docker run --rm -v "${GITHUB_WORKSPACE}:/repo" -w /repo rhysd/actionlint:latest -color
+        shell: bash
+        run: |
+          actionlint() {
+            docker run --rm -v "${GITHUB_WORKSPACE}:/repo" -w /repo rhysd/actionlint:latest "$@"
+          }
+          actionlint -version
+          actionlint -color -verbose

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -21,6 +21,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Run actionlint
-        uses: docker://rhysd/actionlint:latest
-        with:
-          args: -color
+        run: docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:latest -color

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Run actionlint
-        run: docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:latest -color
+        run: docker run --rm -v "${GITHUB_WORKSPACE}:/repo" -w /repo rhysd/actionlint:latest -color


### PR DESCRIPTION
This PR replaces the `uses: docker://rhysd/actionlint:latest` syntax with a direct `docker run` command in the actionlint workflow.

**Changes:**
- Replaced Docker action syntax with `docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:latest -color`
- Removed the `with:` and `args:` sections since arguments are now included directly in the command
- Maintains the same functionality while using standard Docker CLI syntax

**Benefits:**
- More explicit and readable command execution
- Easier to understand and modify for developers familiar with Docker CLI
- Reduces dependency on GitHub Actions Docker action wrapper