### PR TITLE
feat: change default Ruby version to latest on release

### DIFF
--- a/.github/workflows/ruby-release-reusable.yml
+++ b/.github/workflows/ruby-release-reusable.yml
@@ -6,7 +6,7 @@ on:
       ruby-version:
         description: Ruby version
         required: false
-        default: "3.2"
+        default: "ruby" # latest
         type: string
       otp:
         description: One-time password for RubyGems.org


### PR DESCRIPTION
Ref https://github.com/ruby/setup-ruby/blob/829114fc20da43a41d27359103ec7a63020954d4/README.md#supported-version-syntax

> engine only like `ruby` and `truffleruby`, uses the latest stable release of that implementation