### PR TITLE
fix: install compatible npm v11 for Node.js 20 in `nodejs-test-reusable` workflow

### DIFF
--- a/.github/workflows/nodejs-test-reusable.yml
+++ b/.github/workflows/nodejs-test-reusable.yml
@@ -59,6 +59,9 @@ jobs:
             v18.*)
               major_version=10
               ;;
+            v20.*)
+              major_version=11
+              ;;
             *)
               echo "latest=true" >> "${GITHUB_OUTPUT}"
               echo "next-version=$(npm view npm version)" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
npm v12 requires Node.js v22 or later.