### PR TITLE
feat: add `post-version-command` input to `nodejs-release-pr-reusable` workflow

### DIFF
--- a/.github/workflows/nodejs-release-pr-reusable.yml
+++ b/.github/workflows/nodejs-release-pr-reusable.yml
@@ -12,6 +12,10 @@ on:
         description: Reviewers for the pull request (comma-separated)
         required: false
         type: string
+      post-version-command:
+        description: Shell command to run after `npm version`
+        required: false
+        type: string
 
 jobs:
   release-pr:
@@ -81,6 +85,12 @@ jobs:
         run: |
           npm version "${NEW_VERSION}" --no-git-tag-version
           echo "new-version=$(jq -r '.version' package.json)" >> "${GITHUB_OUTPUT}"
+
+      - name: Run post-version command
+        if: ${{ inputs.post-version-command }}
+        env:
+          POST_VERSION_COMMAND: ${{ inputs.post-version-command }}
+        run: eval "${POST_VERSION_COMMAND}"
 
       - name: Get additional info
         id: get-info


### PR DESCRIPTION
Allows running an arbitrary command after `npm version` before a release commit is created.

Use case: when a user turns off hooks, such as `npm run postversion`.